### PR TITLE
Fixes for GSSAPI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ anyhow = "1"
 env_logger = "0.7"
 
 [package.metadata.docs.rs]
-features = ["tls", "chrono", "tds73", "sql-browser-async-std", "sql-browser-tokio", "integrated-auth-gssapi"]
+features = ["tls", "chrono", "tds73", "sql-browser-async-std", "sql-browser-tokio"]
 
 [features]
 default = ["tls", "tds73"]

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -54,13 +54,10 @@ pub enum AuthMethod {
     /// Authenticate with Windows credentials. Only available on Windows
     /// platforms.
     Windows(WindowsAuth),
-    #[cfg(any(windows, doc))]
-    /// Authenticate as the currently logged in user. Only available on Windows
-    /// platforms.
-    WindowsIntegrated,
-    #[cfg(any(feature = "integrated-auth-gssapi", doc))]
-    /// Authenticate as the currently logged in (Kerberos) user. (Enable feature
-    /// `integrated-auth-gssapi`) to enable.
+    #[cfg(any(windows, all(unix, feature = "integrated-auth-gssapi"), doc))]
+    /// Authenticate as the currently logged in user. On Windows uses SSPI and
+    /// Kerberos on Unix platforms.  On Unix platforms the
+    /// `integrated-auth-gssapi` feature needs to be enabled.
     Integrated,
     #[doc(hidden)]
     None,

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -278,11 +278,13 @@ impl AdoNetString {
             #[cfg(windows)]
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => match (user, pw)
             {
-                (None, None) => Ok(AuthMethod::WindowsIntegrated),
+                (None, None) => Ok(AuthMethod::Integrated),
                 _ => Ok(AuthMethod::windows(user.unwrap_or(""), pw.unwrap_or(""))),
             },
             #[cfg(feature = "integrated-auth-gssapi")]
-            Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => Ok(AuthMethod::Integrated),
+            Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => {
+                Ok(AuthMethod::Integrated)
+            }
             _ => Ok(AuthMethod::sql_server(user.unwrap_or(""), pw.unwrap_or(""))),
         }
     }
@@ -482,7 +484,18 @@ mod tests {
         let test_str = "IntegratedSecurity=SSPI";
         let ado = AdoNetString::parse(test_str)?;
 
-        assert_eq!(AuthMethod::WindowsIntegrated, ado.authentication()?);
+        assert_eq!(AuthMethod::Integrated, ado.authentication()?);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(all(feature = "integrated-auth-gssapi", unix))]
+    fn parsing_sspi_authentication() -> crate::Result<()> {
+        let test_str = "IntegratedSecurity=true";
+        let ado = AdoNetString::parse(test_str)?;
+
+        assert_eq!(AuthMethod::Integrated, ado.authentication()?);
 
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[cfg(any(feature = "integrated-auth-gssapi", doc))]
     /// An error from the GSSAPI library.
     #[error("GSSAPI Error: {}", _0)]
-    Gssapi(String)
+    Gssapi(String),
 }
 
 impl From<uuid::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,10 +93,10 @@
 //!
 //! - SQL Server authentication uses the facilities of the database to
 //! authenticate the user.
-//! - Authentication with Windows credentials
-//! - Authentication with currently logged in Windows user / Kerberos credentials
-//! - Authentication with currently logged in Kerberos credentials via GSSAPI (feature =
-//! `integrated-auth-gssapi`)
+//! - On Windows, you can authenticate using the currently logged in user or
+//! specified Windows credentials.
+//! - If enabling the `integrated-auth-gssapi` feature, it is possible to login
+//! with the currently active Kerberos credentials.
 //!
 //! # TLS
 //!


### PR DESCRIPTION
With these changes I think this feature would be ready to merge. What do you think?

- Do not enable `integrated-auth-gssapi` for docs.rs (they probably miss the krb headers).
- Combine `AuthMethod::Integrated` and `AuthMethod::WindowsIntegrated` to `AuthMethod::Integrated` variant for clarity.
- Make the docs a bit more clear (hopefully)